### PR TITLE
Make the `notify` function return its event argument.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 
 - Drop support for Python 3.3.
 
+- Make the ``notify`` function return its event argument. This
+  facilitates testing and higher-level APIs such as those found in
+  `zope.lifecycleevent <https://github.com/zopefoundation/zope.lifecycleevent/issues/11>`_.
+
 
 4.2.0 (2016-02-17)
 ==================

--- a/src/zope/event/__init__.py
+++ b/src/zope/event/__init__.py
@@ -30,3 +30,4 @@ def notify(event):
     """
     for subscriber in subscribers:
         subscriber(event)
+    return event

--- a/src/zope/event/classhandler.py
+++ b/src/zope/event/classhandler.py
@@ -34,7 +34,7 @@ Subscribers are called in class method-resolution order, so only
 new-style event classes are supported, and then by order of registry.
 
     >>> import zope.event
-    >>> zope.event.notify(MySubEvent())
+    >>> _ = zope.event.notify(MySubEvent())
     handler3 MySubEvent
     handler1 MySubEvent
     handler2 MySubEvent

--- a/src/zope/event/tests.py
+++ b/src/zope/event/tests.py
@@ -29,7 +29,7 @@ class Test_notify(unittest.TestCase):
 
     def _callFUT(self, event):
         from zope.event import notify
-        notify(event)
+        return notify(event)
 
     def test_empty(self):
         event = object()
@@ -42,6 +42,10 @@ class Test_notify(unittest.TestCase):
         event = object()
         self._callFUT(event)
         self.assertEqual(dummy, [event])
+
+    def test_returns_argument(self):
+        result = self._callFUT(self)
+        self.assertIs(result, self)
 
 def setUpClassHandlers(test):
     import zope.event


### PR DESCRIPTION
This facilitates testing and higher-level APIs such as those found in
zope.lifecycleevent. It was proposed in https://github.com/zopefoundation/zope.lifecycleevent/issues/11.