### PR TITLE
The sphinx docs for z.e.classhandler use `.. automodule`.

### DIFF
--- a/docs/classhandler.rst
+++ b/docs/classhandler.rst
@@ -2,41 +2,4 @@
  Class-based event handlers
 ============================
 
-A light-weight event-handler framework based on event classes is
-provided by the ``zope.event.classhandler`` module.
-
-Handlers are registered for event classes:
-
-    >>> import zope.event.classhandler
-
-    >>> class MyEvent(object):
-    ...     def __repr__(self):
-    ...         return self.__class__.__name__
-
-    >>> def handler1(event):
-    ...     print("handler1 %r" % event)
-
-    >>> zope.event.classhandler.handler(MyEvent, handler1)
-
-Descriptor syntax:
-
-    >>> @zope.event.classhandler.handler(MyEvent)
-    ... def handler2(event):
-    ...     print("handler2 %r" % event)
-
-    >>> class MySubEvent(MyEvent):
-    ...     pass
-
-    >>> @zope.event.classhandler.handler(MySubEvent)
-    ... def handler3(event):
-    ...     print("handler3 %r" % event)
-
-
-Subscribers are called in class method-resolution order, so only
-new-style event classes are supported, and then by order of registry.
-
-    >>> import zope.event
-    >>> zope.event.notify(MySubEvent())
-    handler3 MySubEvent
-    handler1 MySubEvent
-    handler2 MySubEvent
+.. automodule:: zope.event.classhandler

--- a/docs/classhandler.rst
+++ b/docs/classhandler.rst
@@ -3,3 +3,6 @@
 ============================
 
 .. automodule:: zope.event.classhandler
+    :no-members:
+
+.. autofunction:: handler(event_class, [handler])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.coverage',
+    'sphinx.ext.viewcode',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -45,7 +46,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'zope.event'
-copyright = u'2010, Zope Foundation and Contributors'
+copyright = u'2010-2018, Zope Foundation and Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -202,4 +203,10 @@ latex_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {
+    'https://docs.python.org/': None
+}
+
+autodoc_default_flags = ['members', 'show-inheritance']
+autodoc_member_order = 'bysource'
+autoclass_content = 'both'

--- a/src/zope/event/classhandler.py
+++ b/src/zope/event/classhandler.py
@@ -42,13 +42,14 @@ new-style event classes are supported, and then by order of registry.
 """
 import zope.event
 
+__all__ = [
+    'handler',
+]
+
 registry = {}
 
-def handler(event_class, handler_=None, decorator=False):
-    """
-    handler(event_class, [handler]) -> None
-
-    Define an event handler for a (new-style) class.
+def handler(event_class, handler_=None, _decorator=False):
+    """ Define an event handler for a (new-style) class.
 
     This can be called with a class and a handler, or with just a
     class and the result used as a handler decorator.
@@ -64,7 +65,7 @@ def handler(event_class, handler_=None, decorator=False):
     else:
         registry[event_class].append(handler_)
 
-    if decorator:
+    if _decorator:
         return handler
 
 def dispatch(event):

--- a/src/zope/event/classhandler.py
+++ b/src/zope/event/classhandler.py
@@ -45,7 +45,10 @@ import zope.event
 registry = {}
 
 def handler(event_class, handler_=None, decorator=False):
-    """Define an event handler for a (new-style) class.
+    """
+    handler(event_class, [handler]) -> None
+
+    Define an event handler for a (new-style) class.
 
     This can be called with a class and a handler, or with just a
     class and the result used as a handler decorator.


### PR DESCRIPTION
For two reasons:

1) DRY
2) Ability to cross-reference :mod:`zope.event.classhandler`.

The docstring is identical to the deleted text in the .rst file. 

I also tweaked the sphinx config so that `handler` got documented separately (mostly for cross-ref) and to use HTTPS for python doc.