### PR TITLE
Use an SPDX identifier for the Python license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     name='zope.event',
     version='4.5.1.dev0',
     url='https://github.com/zopefoundation/zope.event',
-    license='ZPL 2.1',
+    license='ZPL-2.1',
     description='Very basic event publishing system',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',


### PR DESCRIPTION
Many automated tools expect the license attribute in setup.py to be an SPDX
compatible identifier (even though PEP 639 has not yet been adopted), so
they can identify the licenses in use by a project.