### PR TITLE
pedantic change to avoid confusing Debian's dh-python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     ],
     include_package_data=True,
     python_requires='>=3.9',
-    install_requires=['setuptools >= 75.8.2'],
+    setup_requires=['setuptools >= 75.8.2'],
     zip_safe=False,
     extras_require={
         'docs': [


### PR DESCRIPTION
otherwise pkg_resources runtime is still getting pulled

we are trying to get rid of it

----

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added documentation for my changes.
- [ ] I included a change log entry in my commits.
